### PR TITLE
fix: `EISDIR` issue while reading file

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,22 +74,22 @@ module.exports = function(
     nodir: true,
     statCache
   })
-    .then(() => {
-      return Promise.all(
-        Object.keys(statCache).map(filepath => {
-          const stat = statCache[filepath]
-          return fs
-            .readFile(filepath, 'utf8')
-            .then(str => gzipSize(str))
-            .then(size => {
-              const name = path.relative(baseDir, filepath)
-              return {
-                path: filepath,
-                name,
-                size: stat.size,
-                gzip: size
-              }
-            })
+  .then((files) => {
+    return Promise.all(
+      files.map(filepath => {
+        const fullFilePath = path.join(baseDir, filepath);
+        return fs
+          .readFile(fullFilePath, 'utf8')
+          .then(str => gzipSize(str))
+          .then(size => {
+            const name = path.relative(baseDir, fullFilePath);
+            return {
+              path: fullFilePath,
+              name,
+              size: fs.statSync(fullFilePath).size,
+              gzip: size
+            }
+          })
         })
       )
     })


### PR DESCRIPTION
The following error occurred while reading the file.

```bash
[Error: EISDIR: illegal operation on a directory, read] {
   errno: -21;
   code: 'EISDIR',
   syscall: 'read'
}
```
I need to read a file, but I'm having trouble reading a directory.